### PR TITLE
fix(tree): remove dead group-unavailable handler

### DIFF
--- a/mySQLPunk/Form1.cs
+++ b/mySQLPunk/Form1.cs
@@ -6762,13 +6762,6 @@ namespace mySQLPunk
             return menu;
         }
 
-        private void ShowGroupUnavailable()
-        {
-            string message = Localization.T("Menu.GroupUnavailable");
-            UpdateMainStatus(message);
-            MessageBox.Show(message, Localization.T("Menu.NewGroup"), MessageBoxButtons.OK, MessageBoxIcon.Information);
-        }
-
         private void RefreshConnectionList()
         {
             drawLists();

--- a/mySQLPunk/Localization.cs
+++ b/mySQLPunk/Localization.cs
@@ -58,7 +58,6 @@ namespace mySQLPunk
             Add("Menu.ColorBlue", "藍色", "Blue");
             Add("Menu.ColorPurple", "紫色", "Purple");
             Add("Menu.ManageGroups", "管理群組", "Manage Groups");
-            Add("Menu.GroupUnavailable", "尚未建立群組功能", "Groups are not available yet");
             Add("Menu.GroupName", "群組名稱", "Group Name");
             Add("Menu.GroupNamePrompt", "請輸入群組名稱：", "Enter a group name:");
             Add("Menu.MoveToGroup", "移至群組...", "Move to Group...");


### PR DESCRIPTION
## Summary
- Remove unused `ShowGroupUnavailable` and `Menu.GroupUnavailable` left over from the misleading object-classification **New Group** menu item.
- Connection-level group creation on blank tree area remains unchanged.

## Related issue
Fixes #13